### PR TITLE
fix: don't swallow exceptions

### DIFF
--- a/MhLabs.AwsSignedHttpClient/Extensions/HttpClientExtensions.cs
+++ b/MhLabs.AwsSignedHttpClient/Extensions/HttpClientExtensions.cs
@@ -73,15 +73,8 @@ namespace MhLabs.AwsSignedHttpClient
                 return content as TReturn;
             }
 
-            TReturn result = default(TReturn);
+            return JsonConvert.DeserializeObject<TReturn>(content);
 
-            try
-            {
-                result = JsonConvert.DeserializeObject<TReturn>(content);
-            }
-            catch { }
-
-            return result;
         }
     }
 }

--- a/MhLabs.AwsSignedHttpClient/MhLabs.AwsSignedHttpClient.csproj
+++ b/MhLabs.AwsSignedHttpClient/MhLabs.AwsSignedHttpClient.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>8.0.1</Version>
+    <Version>8.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Making sure that we don't swallow the exceptions when the json serialization occurs.